### PR TITLE
Add Lemmy.Net to libraries section

### DIFF
--- a/template.md
+++ b/template.md
@@ -91,6 +91,7 @@ Name | Description | GitHub Activity
 * [tjkessler/plemmy](@ghRepo)
 * [hjiangsu/lemmy-dart](@ghRepo)
 [Lemmy.py](https://codeberg.org/retiolus/Lemmy.py) | Python bindings to the Lemmy API |
+* [Rickebo/Lemmy.Net](@ghRepo)
 
 ### Tools
 


### PR DESCRIPTION
Adds the Lemmy.Net library for interacting with the Lemmy API in .NET to the libraries section