### PR TITLE
Add Sync for Lemmy

### DIFF
--- a/template.md
+++ b/template.md
@@ -87,6 +87,7 @@ Name | Description | GitHub Activity | OS compatibility
 * [mani-sh-reddy/Lunar-Lemmy-iOS](@ghRepo) | iOS
 * [lavalleeale/lemmios](@ghRepo) | iOS
 [Infinity-For-Lemmy](https://codeberg.org/Bazsalanszky/Infinity-For-Lemmy) | A Lemmy client forked from the Infinity for Reddit project | | Android
+[Sync for Lemmy](https://play.google.com/store/apps/details?id=io.syncapps.lemmy_sync) | A Lemmy client by the creator of Sync for Reddit | | Android
 
 ### Libraries
 


### PR DESCRIPTION
It was recently released and is a successor of the popular (now defunct) Sync for Reddit app.