### PR TITLE
Add MV-GH/lemmy_openapi_spec, Unofficial Lemmy OpenAPI documentation 

### DIFF
--- a/template.md
+++ b/template.md
@@ -154,6 +154,7 @@ Name | Description | GitHub Activity
 Name | Description | GitHub Activity
 ---- | ----------- | ---------------
 * [amirzaidi/lemmy](@ghRepo)
+* [MV-GH/lemmy_openapi_spec](@ghRepo) | Unofficial Lemmy OpenAPI documentation 
 
 ## Misc.
 


### PR DESCRIPTION
I added it under Guides but a new Documentation section would probably be better. 