### PR TITLE
Add lemmy rust client to list of libraries

### DIFF
--- a/template.md
+++ b/template.md
@@ -108,6 +108,7 @@ Name | Description | GitHub Activity
 * [Rickebo/Lemmy.Net](@ghRepo)
 * [mdowst/Lemmy-PowerShell](@ghRepo)
 * [RikudouSage/LemmyApi](@ghRepo)
+* [SleeplessOne1917/lemmy-client-rs](@ghRepo) 
 
 ### Userscripts / Browser plugins
 


### PR DESCRIPTION
I just published an API wrapper for rust that fills a similar role to [lemmy-js-client](https://github.com/LemmyNet/lemmy-js-client). It should be a good addition to this list.