### PR TITLE
Move Voyager to apps section

### DIFF
--- a/template.md
+++ b/template.md
@@ -53,7 +53,6 @@ Name | Description | GitHub Activity
 
 Name | Description | GitHub Activity | URL
 ---- | ----------- | --------------- | ---
-* [aeharding/voyager](@ghRepo) | [vger.app](https://vger.app/)
 * [Xyphyn/photon](@ghRepo) | [photon.xylight.dev](https://photon.xylight.dev)
 * [rystaf/mlmym](@ghRepo) | [mlmym.org](https://mlmym.org/)
 * [sheodox/alexandrite](@ghRepo) | [alexandrite.app](https://alexandrite.app/)
@@ -70,6 +69,7 @@ Name | Description | GitHub Activity | URL
 
 Name | Description | GitHub Activity | OS compatibility
 ---- | ----------- | --------------- | ----------------
+* [aeharding/voyager](@ghRepo) | Android, iOS, Web
 * [dessalines/jerboa](@ghRepo) | Android
 * [thunder-app/thunder](@ghRepo) | Android, iOS
 * [memmy-app/memmy](@ghRepo) | iOS


### PR DESCRIPTION
Hello!

I am the Voyager dev.

Since Voyager has been added to this list, Voyager now offers an app in Play Store/Apple Store/F-Droid, and that is what most users are using.

Because Voyager is more an app than alternate front-end, I've moved it to the apps section.

The alternative is to put it in both places. LMK what you prefer.

Thanks!